### PR TITLE
Need to set system MAC the same on both MC-LAG members

### DIFF
--- a/configs/pod1-lf1.yml
+++ b/configs/pod1-lf1.yml
@@ -24,6 +24,7 @@ srl_nokia-interfaces:interface:
       lacp: 
         interval: FAST
         lacp-mode: ACTIVE
+        admin-key: 1
         system-id-mac: 02:00:00:00:02:01
     
   - name: ethernet-1/1

--- a/configs/pod1-lf1.yml
+++ b/configs/pod1-lf1.yml
@@ -24,6 +24,7 @@ srl_nokia-interfaces:interface:
       lacp: 
         interval: FAST
         lacp-mode: ACTIVE
+        system-id-mac: 02:00:00:00:02:01
     
   - name: ethernet-1/1
     admin-state: enable


### PR DESCRIPTION
Else LACP won't come up. 

Same for admin-key, see https://documentation.nokia.com/srlinux/22-11/SR_Linux_Book_Files/Advanced_Solutions_Guide/evpn-l2-multihome.html