### PR TITLE
Alternative way to provision host containers

### DIFF
--- a/configs/interfaces.cab1-srv1
+++ b/configs/interfaces.cab1-srv1
@@ -1,0 +1,29 @@
+auto lo
+iface lo inet loopback
+
+auto bond0
+iface bond0 inet static
+  address 192.168.0.1
+  netmask 255.255.255.248
+  # gateway 10.0.1.1
+
+  # bond0 uses standard IEEE 802.3ad LACP bonding protocol
+  bond-mode 4
+  # bond-miimon 100
+  bond-lacp-rate fast
+  bond-xmit-hash-policy layer3+4
+  bond-slaves eth1 eth2
+
+iface bond0 inet6 static
+  address 2001:1::101
+  netmask 64
+  # gateway 2001:100:127:10::2
+  pre-up echo 0 > /proc/sys/net/ipv6/conf/bond0/accept_ra
+
+auto vlan200
+iface vlan200 inet static
+	address 10.200.200.11
+	netmask 255.255.255.0
+	# gateway 10.200.200.1
+	vlan-raw-device bond0
+  up ip route add 10.0.0.0/8 via 10.200.200.1 || true


### PR DESCRIPTION
I ran into an issue where I didn't have access to an alpine-host container image, and I couldn't get the teaming to work.

By using:
```
...
pod1-cab1-srv1:
      group: pod1-srv
      kind: linux
      binds:
      - /lib/modules:/lib/modules:ro # for bonding module
      - configs/interfaces.cab1-srv1:/etc/network/interfaces
```

I was able to get working LAGs